### PR TITLE
Correct product image size

### DIFF
--- a/src/css/large.css
+++ b/src/css/large.css
@@ -1,0 +1,5 @@
+@media (min-width: 992px) {
+  img#productImage {
+    max-width: 80%;
+  }
+}

--- a/src/css/medium.css
+++ b/src/css/medium.css
@@ -1,0 +1,5 @@
+@media (min-width: 768px) and (max-width: 991px) {
+  img#productImage {
+    max-width: 85%;
+  }
+}

--- a/src/css/small.css
+++ b/src/css/small.css
@@ -1,0 +1,5 @@
+@media (max-width: 767px) {
+  img#productImage {
+    max-width: 90%;
+  }
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -166,6 +166,11 @@ button {
   width: 100%;
 }
 
+.product-detail img {
+  margin: 0 auto;
+  display: block;
+}
+
 /* Start cart list card styles */
 .cart-card {
   display: grid;

--- a/src/product_pages/index.html
+++ b/src/product_pages/index.html
@@ -9,6 +9,9 @@
     <title>Sleep Outside | Cedar Ridge Rimrock 2-person tent</title>
 
     <link rel="stylesheet" href="../css/style.css" />
+    <link rel="stylesheet" href="../css/small.css" />
+    <link rel="stylesheet" href="../css/medium.css" />
+    <link rel="stylesheet" href="../css/large.css" />
 
     <script src="../js/product.js" type="module"></script>
   </head>
@@ -58,7 +61,9 @@
       <section class="product-detail">
         <h3 id="productName"></h3>
         <h2 class="divider" id="productNameWithoutBrand"></h2>
-        <img id="productImage" class="divider" src="" alt="" />
+        <div class="productImage-container divider">
+          <img id="productImage" src="" alt="" />
+        </div>
         <p class="product-card__price" id="productFinalPrice"></p>
         <p class="product__color" id="productColorName"></p>
         <p class="product__description" id="productDescriptionHtmlSimple"></p>


### PR DESCRIPTION
Added 3 pages in the CSS folder to handle small, medium, and large screen sizes.
Added #productImage-container to keep the border 100% of the width without affecting the width size of the product image. 
The size of the images located on the home page remains the same (100% width).